### PR TITLE
feat: :sparkles: Adiciona a especificação do OpenAPI Swagger para doc…

### DIFF
--- a/www/app/Http/Controllers/ClienteController.php
+++ b/www/app/Http/Controllers/ClienteController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Filters\ClienteFilter;
 use App\Http\Requests\CreateClienteRequest;
-use App\Http\Requests\StoreClienteRequest;
 use App\Http\Requests\UpdateClienteRequest;
 use App\Models\Cliente;
 use App\Services\ClienteService;
@@ -13,6 +12,41 @@ use Throwable;
 
 class ClienteController extends Controller
 {
+
+    /**
+     * @OA\Get(
+     *   path="/api/clientes",
+     *   operationId="getClientesIndex",
+     *   tags={"Clientes"},
+     *   security={{"sanctum":{}}},
+     *   summary="Exibe lista de clientes",
+     *   description="",
+     *   @OA\Parameter(name="id", description="Filtrar pelo ID", in="query", @OA\Schema(type="integer")),
+     *   @OA\Parameter(name="nome", description="Filtrar pelo nome", in="query", @OA\Schema(type="string")),
+     *   @OA\Parameter(name="email", description="Filtrar pelo email", in="query", @OA\Schema(type="string")),
+     *   @OA\Parameter(name="telefone", description="Filtrar pelo telefone", in="query", @OA\Schema(type="string")),
+     *   @OA\Parameter(name="cpf_cnpj", description="Filtrar pelo CPF/CNPJ", in="query", @OA\Schema(type="string")),
+     *   @OA\Parameter(name="ordenar_id", description="Ordenar pelo ID", in="query", @OA\Schema(type="string", enum={"asc", "desc"})),
+     *   @OA\Parameter(name="ordenar_nome", description="Ordenar pelo nome", in="query", @OA\Schema(type="string", enum={"asc", "desc"})),
+     *   @OA\Response(
+     *       response=200,
+     *       description="OK",
+     *       @OA\JsonContent(
+     *           @OA\Property(property="message", type="string", example="Lista de clientes."),
+     *           @OA\Property(property="content",type="object",
+     *               @OA\Property(property="data", type="array",
+     *                  @OA\Items(type="object", ref="#/components/schemas/ClienteResource"),
+     *               ),
+     *               @OA\Property(property="meta", type="object", ref="#/components/schemas/CustomPaginator"),
+     *           ),
+     *           @OA\Property(property="code",type="integer",example="200"),
+     *       )
+     *   ),
+     *   @OA\Response(response=400, description="Bad request."),
+     *   @OA\Response(response=401, description="Unauthorized."),
+     *   @OA\Response(response=403, description="Forbidden."),
+     * )
+     */
     public function index(ClienteFilter $filters, ClienteService $clienteService): JsonResponse
     {
         try {
@@ -31,6 +65,44 @@ class ClienteController extends Controller
         }
     }
 
+    /**
+     * @OA\Post(
+     *   path="/api/clientes",
+     *   operationId="postClientesStore",
+     *   tags={"Clientes"},
+     *   security={{"sanctum":{}}},
+     *   summary="Cadastra novo cliente",
+     *   description="",
+     *   @OA\RequestBody(
+     *       required=true,
+     *       @OA\JsonContent(ref="#/components/schemas/CreateClienteRequest"),
+     *   ),
+     *   @OA\Response(
+     *     response=200,
+     *     description="OK",
+     *     @OA\JsonContent(
+     *        @OA\Property(property="message",type="string",example="Cliente cadastrado com sucesso."),
+     *        @OA\Property(property="content",type="object", ref="#/components/schemas/ClienteResource"),
+     *        @OA\Property(property="code",type="integer",example="200"),
+     *     )
+     *   ),
+     *   @OA\Response(response=400, description="Bad request."),
+     *   @OA\Response(response=401, description="Unauthorized."),
+     *   @OA\Response(response=403, description="Forbidden."),
+     *   @OA\Response(
+     *       response=422,
+     *       description="Unprocessable Content.",
+     *       @OA\JsonContent(
+     *          @OA\Property(property="message",type="string",example="O campo cpf cnpj não é um CPF ou CNPJ válido."),
+     *          @OA\Property(property="errors",type="object",
+     *               @OA\Property(property="nome", type="array",
+     *                   @OA\Items(type="string", example="O campo cpf cnpj não é um CPF ou CNPJ válido.")
+     *               ),
+     *          ),
+     *       ),
+     *   ),
+     * )
+     */
     public function store(CreateClienteRequest $createClientRequest, ClienteService $clienteService): JsonResponse
     {
         try {
@@ -49,6 +121,37 @@ class ClienteController extends Controller
         }
     }
 
+    /**
+     * @OA\Get(
+     *   path="/api/clientes/{id}",
+     *   operationId="getClientesShow",
+     *   tags={"Clientes"},
+     *   security={{"sanctum":{}}},
+     *   summary="Pesquisa cliente pelo ID",
+     *   description="",
+     *   @OA\Parameter(
+     *       name="id",
+     *       description="ID do cliente",
+     *       example=2,
+     *       required=true,
+     *       in="path",
+     *       @OA\Schema(type="integer")
+     *  ),
+     *   @OA\Response(
+     *     response=200,
+     *     description="OK",
+     *     @OA\JsonContent(
+     *        @OA\Property(property="message",type="string",example="Cliente ID: 2"),
+     *        @OA\Property(property="content",type="object", ref="#/components/schemas/ClienteResource"),
+     *        @OA\Property(property="code",type="integer",example="200"),
+     *     )
+     *   ),
+     *   @OA\Response(response=400, description="Bad request."),
+     *   @OA\Response(response=401, description="Unauthenticated."),
+     *   @OA\Response(response=403, description="Forbidden."),
+     *   @OA\Response(response=404, description="Not Found."),
+     * )
+     */
     public function show(Cliente $cliente, ClienteService $clienteService)
     {
         try {
@@ -67,6 +170,52 @@ class ClienteController extends Controller
         }
     }
 
+    /**
+     * @OA\Put(
+     *   path="/api/clientes/{id}",
+     *   operationId="putClientesUpdate",
+     *   tags={"Clientes"},
+     *   security={{"sanctum":{}}},
+     *   summary="Atualiza os dados do cliente",
+     *   description="",
+     *   @OA\Parameter(
+     *       name="id",
+     *       description="ID do cliente",
+     *       example=2,
+     *       required=true,
+     *       in="path",
+     *       @OA\Schema(type="integer")
+     *  ),
+     *   @OA\RequestBody(required=true,
+     *       @OA\JsonContent(ref="#/components/schemas/UpdateClienteRequest"),
+     *   ),
+     *   @OA\Response(
+     *     response=200,
+     *     description="OK",
+     *     @OA\JsonContent(
+     *        @OA\Property(property="message",type="string",example="Cliente atualizado com sucesso."),
+     *        @OA\Property(property="content",type="object", ref="#/components/schemas/ClienteResource"),
+     *        @OA\Property(property="code",type="integer",example="200"),
+     *     )
+     *   ),
+     *   @OA\Response(response=400, description="Bad request."),
+     *   @OA\Response(response=401, description="Unauthenticated."),
+     *   @OA\Response(response=403, description="Forbidden."),
+     *   @OA\Response(response=404, description="Not Found."),
+     *   @OA\Response(
+     *       response=422,
+     *       description="Unprocessable Content.",
+     *       @OA\JsonContent(
+     *          @OA\Property(property="message",type="string",example="O campo cpf cnpj não é um CPF ou CNPJ válido."),
+     *          @OA\Property(property="errors",type="object",
+     *               @OA\Property(property="email", type="array",
+     *                   @OA\Items(type="string", example="O campo cpf cnpj não é um CPF ou CNPJ válido.")
+     *               ),
+     *          ),
+     *       ),
+     *   ),
+     * )
+     */
     public function update(Cliente $cliente, UpdateClienteRequest $updateClienteRequest, ClienteService $clienteService)
     {
         try {

--- a/www/app/Http/Controllers/Controller.php
+++ b/www/app/Http/Controllers/Controller.php
@@ -7,6 +7,39 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Routing\Controller as BaseController;
 
+/**
+ * @OA\Info(
+ *   version="1.0.0",
+ *   title="Gestao Projetos de Energia Solar",
+ *   description="Sistema CRUD desenvolvido utilizando a framework Laravel em PHP é voltado para a gestão de projetos de energia solar. Ele adere aos princípios da arquitetura limpa (Clean Architecture), incorporando testes unitários para assegurar a qualidade do código. Além disso, oferece uma documentação abrangente para facilitar o entendimento e a manutenção do sistema.",
+ *   @OA\Contact(email="adriano@instalustres.com.br"),
+ *   @OA\License(
+ *       name="Apache 2.0",
+ *       url="http://www.apache.org/licenses/LICENSE-2.0.html"
+ *   )
+ * )
+ *
+ * @OA\Server(
+ *   url=L5_SWAGGER_CONST_HOST,
+ *   description="Servidor local"
+ * )
+ *
+ * @OA\Tag(
+ *   name="Login",
+ *   description="Endpoint para efetuar login"
+ * )
+ *
+ * @OA\Tag(
+ *   name="Integradores",
+ *   description="Endpoints para manutenção dos Integradores (Somente integrador do tipo 'ADMIN')",
+ * )
+ *
+ * @OA\Tag(
+ *   name="Clientes",
+ *   description="Endpoints para manutenção dos Clientes",
+ * )
+ *
+ */
 class Controller extends BaseController
 {
     use AuthorizesRequests, ValidatesRequests, HttpResponse;

--- a/www/app/Http/Controllers/IntegradorController.php
+++ b/www/app/Http/Controllers/IntegradorController.php
@@ -14,6 +14,41 @@ use Throwable;
 
 class IntegradorController extends Controller
 {
+
+    /**
+     * @OA\Get(
+     *   path="/api/integradores",
+     *   operationId="getIntegradoresIndex",
+     *   tags={"Integradores"},
+     *   security={{"sanctum":{}}},
+     *   summary="Exibe lista de integradores",
+     *   description="",
+     *   @OA\Parameter(name="id", description="Filtrar pelo ID", in="query", @OA\Schema(type="integer")),
+     *   @OA\Parameter(name="nome", description="Filtrar pelo nome", in="query", @OA\Schema(type="string")),
+     *   @OA\Parameter(name="email", description="Filtrar pelo email", in="query", @OA\Schema(type="string")),
+     *   @OA\Parameter(name="tipo", description="Filtrar pelo tipo", in="query", @OA\Schema(type="string", enum={"INTEGRADOR", "ADMIN"})),
+     *   @OA\Parameter(name="ativo", description="Filtrar pelo status", in="query", @OA\Schema(type="integer", enum={0, 1})),
+     *   @OA\Parameter(name="ordenar_id", description="Ordenar pelo ID", in="query", @OA\Schema(type="string", enum={"asc", "desc"})),
+     *   @OA\Parameter(name="ordenar_nome", description="Ordenar pelo nome", in="query", @OA\Schema(type="string", enum={"asc", "desc"})),
+     *   @OA\Response(
+     *       response=200,
+     *       description="OK",
+     *       @OA\JsonContent(
+     *           @OA\Property(property="message", type="string", example="Lista de integradores."),
+     *           @OA\Property(property="content",type="object",
+     *               @OA\Property(property="data", type="array",
+     *                  @OA\Items(type="object", ref="#/components/schemas/IntegradorResource"),
+     *               ),
+     *               @OA\Property(property="meta", type="object", ref="#/components/schemas/CustomPaginator"),
+     *           ),
+     *           @OA\Property(property="code",type="integer",example="200"),
+     *       )
+     *   ),
+     *   @OA\Response(response=400, description="Bad request."),
+     *   @OA\Response(response=401, description="Unauthorized."),
+     *   @OA\Response(response=403, description="Forbidden."),
+     * )
+     */
     public function index(IntegradorFilter $filters, IntegradorService $integradorService): JsonResponse
     {
         try {
@@ -32,6 +67,44 @@ class IntegradorController extends Controller
         }
     }
 
+    /**
+     * @OA\Post(
+     *   path="/api/integradores",
+     *   operationId="postIntegradoresStore",
+     *   tags={"Integradores"},
+     *   security={{"sanctum":{}}},
+     *   summary="Cadastra novo integrador",
+     *   description="",
+     *   @OA\RequestBody(
+     *       required=true,
+     *       @OA\JsonContent(ref="#/components/schemas/CreateIntegradorRequest"),
+     *   ),
+     *   @OA\Response(
+     *     response=200,
+     *     description="OK",
+     *     @OA\JsonContent(
+     *        @OA\Property(property="message",type="string",example="Integrador cadastrado com sucesso."),
+     *        @OA\Property(property="content",type="object", ref="#/components/schemas/IntegradorResource"),
+     *        @OA\Property(property="code",type="integer",example="200"),
+     *     )
+     *   ),
+     *   @OA\Response(response=400, description="Bad request."),
+     *   @OA\Response(response=401, description="Unauthorized."),
+     *   @OA\Response(response=403, description="Forbidden."),
+     *   @OA\Response(
+     *       response=422,
+     *       description="Unprocessable Content.",
+     *       @OA\JsonContent(
+     *          @OA\Property(property="message",type="string",example="O campo nome é obrigatório. (e mais 1 erro)"),
+     *          @OA\Property(property="errors",type="object",
+     *               @OA\Property(property="nome", type="array",
+     *                   @OA\Items(type="string", example="O campo nome é obrigatório.")
+     *               ),
+     *          ),
+     *       ),
+     *   ),
+     * )
+     */
     public function store(CreateIntegradorRequest $createIntegradorRequest, IntegradorService $integradorService): JsonResponse
     {
         try {
@@ -50,6 +123,42 @@ class IntegradorController extends Controller
         }
     }
 
+    /**
+     * @OA\Post(
+     *   path="/api/auth/login",
+     *   operationId="postIntegradoresLogin",
+     *   tags={"Login"},
+     *   summary="Envie seu e-mail e senha e retornaremos um token. Use o token no cabeçalho 'Authorization' da requisição como 'Bearer TOKEN'",
+     *   description="",
+     *   @OA\RequestBody(
+     *       required=true,
+     *       @OA\JsonContent(ref="#/components/schemas/LoginIntegradorRequest"),
+     *   ),
+     *   @OA\Response(
+     *     response=200,
+     *     description="OK",
+     *     @OA\JsonContent(
+     *        @OA\Property(property="message",type="string",example="Login efetuado com sucesso."),
+     *        @OA\Property(property="content",type="string",example="99|OOawESyfhebDhYX0LXxnn5as3fV1R3B79uZvH22Ec0df7515"),
+     *        @OA\Property(property="code",type="integer",example="200"),
+     *     )
+     *   ),
+     *   @OA\Response(response=400, description="Bad request."),
+     *   @OA\Response(response=401, description="Unauthenticated."),
+     *   @OA\Response(
+     *       response=422,
+     *       description="Unprocessable Content.",
+     *       @OA\JsonContent(
+     *          @OA\Property(property="message",type="string",example="O campo email é obrigatório. (e mais 1 erro)"),
+     *          @OA\Property(property="errors",type="object",
+     *               @OA\Property(property="email", type="array",
+     *                   @OA\Items(type="string", example="O campo email é obrigatório.")
+     *               ),
+     *          ),
+     *       ),
+     *   ),
+     * )
+     */
     public function login(LoginIntegradorRequest $loginIntegradorRequest, IntegradorService $integradorService): JsonResponse
     {
         try {
@@ -68,6 +177,52 @@ class IntegradorController extends Controller
         }
     }
 
+    /**
+     * @OA\Put(
+     *   path="/api/integradores/{id}",
+     *   operationId="putIntegradoresUpdate",
+     *   tags={"Integradores"},
+     *   security={{"sanctum":{}}},
+     *   summary="Atualiza os dados do integrador",
+     *   description="",
+     *   @OA\Parameter(
+     *       name="id",
+     *       description="ID do integrador",
+     *       example=2,
+     *       required=true,
+     *       in="path",
+     *       @OA\Schema(type="integer")
+     *  ),
+     *   @OA\RequestBody(required=true,
+     *       @OA\JsonContent(ref="#/components/schemas/UpdateIntegradorRequest"),
+     *   ),
+     *   @OA\Response(
+     *     response=200,
+     *     description="OK",
+     *     @OA\JsonContent(
+     *        @OA\Property(property="message",type="string",example="Integrador atualizado com sucesso."),
+     *        @OA\Property(property="content",type="object", ref="#/components/schemas/IntegradorResource"),
+     *        @OA\Property(property="code",type="integer",example="200"),
+     *     )
+     *   ),
+     *   @OA\Response(response=400, description="Bad request."),
+     *   @OA\Response(response=401, description="Unauthenticated."),
+     *   @OA\Response(response=403, description="Forbidden."),
+     *   @OA\Response(response=404, description="Not Found."),
+     *   @OA\Response(
+     *       response=422,
+     *       description="Unprocessable Content.",
+     *       @OA\JsonContent(
+     *          @OA\Property(property="message",type="string",example="O campo email já está sendo utilizado."),
+     *          @OA\Property(property="errors",type="object",
+     *               @OA\Property(property="email", type="array",
+     *                   @OA\Items(type="string", example="O campo email já está sendo utilizado.")
+     *               ),
+     *          ),
+     *       ),
+     *   ),
+     * )
+     */
     public function update(Integrador $integrador, UpdateIntegradorRequest $updateIntegradorRequest, IntegradorService $integradorService): JsonResponse
     {
         try {
@@ -86,6 +241,52 @@ class IntegradorController extends Controller
         }
     }
 
+    /**
+     * @OA\Patch(
+     *   path="/api/integradores/{id}/tipo",
+     *   operationId="pathIntegradoresType",
+     *   tags={"Integradores"},
+     *   security={{"sanctum":{}}},
+     *   summary="Atualiza o tipo do integrador",
+     *   description="",
+     *   @OA\Parameter(
+     *       name="id",
+     *       description="ID do integrador",
+     *       example=2,
+     *       required=true,
+     *       in="path",
+     *       @OA\Schema(type="integer")
+     *  ),
+     *   @OA\RequestBody(required=true,
+     *       @OA\JsonContent(ref="#/components/schemas/UpdateIntegradorTipoRequest"),
+     *   ),
+     *   @OA\Response(
+     *     response=200,
+     *     description="OK",
+     *     @OA\JsonContent(
+     *        @OA\Property(property="message",type="string",example="Tipo de integrador atualizado com sucesso."),
+     *        @OA\Property(property="content",type="object", ref="#/components/schemas/IntegradorResource"),
+     *        @OA\Property(property="code",type="integer",example="200"),
+     *     )
+     *   ),
+     *   @OA\Response(response=400, description="Bad request."),
+     *   @OA\Response(response=401, description="Unauthenticated."),
+     *   @OA\Response(response=403, description="Forbidden."),
+     *   @OA\Response(response=404, description="Not Found."),
+     *   @OA\Response(
+     *       response=422,
+     *       description="Unprocessable Content.",
+     *       @OA\JsonContent(
+     *          @OA\Property(property="message",type="string",example="O campo tipo selecionado é inválido."),
+     *          @OA\Property(property="errors",type="object",
+     *               @OA\Property(property="email", type="array",
+     *                   @OA\Items(type="string", example="O campo tipo selecionado é inválido.")
+     *               ),
+     *          ),
+     *       ),
+     *   ),
+     * )
+     */
     public function type(Integrador $integrador, UpdateIntegradorTipoRequest $updateIntegradorTipoRequest, IntegradorService $integradorService): JsonResponse
     {
         try {
@@ -104,6 +305,37 @@ class IntegradorController extends Controller
         }
     }
 
+    /**
+     * @OA\Patch(
+     *   path="/api/integradores/{id}/desativar",
+     *   operationId="pathIntegradoresDeactive",
+     *   tags={"Integradores"},
+     *   security={{"sanctum":{}}},
+     *   summary="Desativar o integrador",
+     *   description="",
+     *   @OA\Parameter(
+     *       name="id",
+     *       description="ID do integrador",
+     *       example=2,
+     *       required=true,
+     *       in="path",
+     *       @OA\Schema(type="integer")
+     *  ),
+     *   @OA\Response(
+     *     response=200,
+     *     description="OK",
+     *     @OA\JsonContent(
+     *        @OA\Property(property="message",type="string",example="Integrador desativado com sucesso."),
+     *        @OA\Property(property="content",type="object", ref="#/components/schemas/IntegradorResource"),
+     *        @OA\Property(property="code",type="integer",example="200"),
+     *     )
+     *   ),
+     *   @OA\Response(response=400, description="Bad request."),
+     *   @OA\Response(response=401, description="Unauthenticated."),
+     *   @OA\Response(response=403, description="Forbidden."),
+     *   @OA\Response(response=404, description="Not Found."),
+     * )
+     */
     public function deactive(Integrador $integrador, IntegradorService $integradorService): JsonResponse
     {
         try {
@@ -122,6 +354,37 @@ class IntegradorController extends Controller
         }
     }
 
+    /**
+     * @OA\Patch(
+     *   path="/api/integradores/{id}/ativar",
+     *   operationId="pathIntegradoresActive",
+     *   tags={"Integradores"},
+     *   security={{"sanctum":{}}},
+     *   summary="Ativar o integrador",
+     *   description="",
+     *   @OA\Parameter(
+     *       name="id",
+     *       description="ID do integrador",
+     *       example=2,
+     *       required=true,
+     *       in="path",
+     *       @OA\Schema(type="integer")
+     *  ),
+     *   @OA\Response(
+     *     response=200,
+     *     description="OK",
+     *     @OA\JsonContent(
+     *        @OA\Property(property="message",type="string",example="Integrador ativado com sucesso."),
+     *        @OA\Property(property="content",type="object", ref="#/components/schemas/IntegradorResource"),
+     *        @OA\Property(property="code",type="integer",example="200"),
+     *     )
+     *   ),
+     *   @OA\Response(response=400, description="Bad request."),
+     *   @OA\Response(response=401, description="Unauthenticated."),
+     *   @OA\Response(response=403, description="Forbidden."),
+     *   @OA\Response(response=404, description="Not Found."),
+     * )
+     */
     public function active(Integrador $integrador, IntegradorService $integradorService): JsonResponse
     {
         try {

--- a/www/app/Http/Kernel.php
+++ b/www/app/Http/Kernel.php
@@ -42,6 +42,7 @@ class Kernel extends HttpKernel
             // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             \Illuminate\Routing\Middleware\ThrottleRequests::class . ':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\EnforceJson::class,
         ],
     ];
 

--- a/www/app/Http/Middleware/EnforceJson.php
+++ b/www/app/Http/Middleware/EnforceJson.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnforceJson
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $request->headers->set('Accept', 'application/json');
+
+        return $next($request);
+    }
+}

--- a/www/app/Http/Requests/CreateClienteRequest.php
+++ b/www/app/Http/Requests/CreateClienteRequest.php
@@ -4,18 +4,30 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
+/**
+ * @OA\Schema(
+ *   title="Requisição para gravar cliente",
+ *   type="object",
+ *   required={"nome", "email", "telefone", "cpf_cnpj"}
+ * )
+ */
 class CreateClienteRequest extends FormRequest
 {
     /**
      * Get the validation rules that apply to the request.
+     *
+     * @OA\Property(property="nome",type="string",example="Cliente 01"),
+     * @OA\Property(property="email",type="string",example="cliente-01@admin.com"),
+     * @OA\Property(property="telefone",type="string",example="(11) 99999-9990"),
+     * @OA\Property(property="cpf_cnpj",type="string",example="999.999.999-99"),
      *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {
         return [
-            'email'         => "required|email|unique:clientes,email,null,null,integrador_id,{$this->user()->id}",
             'nome'          => 'required|max:100',
+            'email'         => "required|email|unique:clientes,email,null,null,integrador_id,{$this->user()->id}",
             'telefone'      => 'required|celular_com_ddd',
             'cpf_cnpj'      => "required|cpf_ou_cnpj|unique:clientes,cpf_cnpj,null,null,integrador_id,{$this->user()->id}",
         ];

--- a/www/app/Http/Requests/CreateIntegradorRequest.php
+++ b/www/app/Http/Requests/CreateIntegradorRequest.php
@@ -4,10 +4,23 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
+/**
+ * @OA\Schema(
+ *   title="Requisição para gravar integrador",
+ *   type="object",
+ *   required={"nome", "email", "tipo", "password", "password_confirmation"}
+ * )
+ */
 class CreateIntegradorRequest extends FormRequest
 {
     /**
      * Get the validation rules that apply to the request.
+     *
+     * @OA\Property(property="nome",type="string",example="admin@admin.com"),
+     * @OA\Property(property="email",type="string",example="admin@admin.com"),
+     * @OA\Property(property="tipo",type="string",example="INTEGRADOR"),
+     * @OA\Property(property="password",type="string",example="Admin@123"),
+     * @OA\Property(property="password_confirmation",type="string",example="Admin@123"),
      *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */

--- a/www/app/Http/Requests/LoginIntegradorRequest.php
+++ b/www/app/Http/Requests/LoginIntegradorRequest.php
@@ -4,10 +4,20 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
+/**
+ * @OA\Schema(
+ *   title="Requisição para efetuar login",
+ *   type="object",
+ *   required={"email", "password"}
+ * )
+ */
 class LoginIntegradorRequest extends FormRequest
 {
     /**
      * Get the validation rules that apply to the request.
+     *
+     * @OA\Property(property="email",type="string",example="admin@admin.com"),
+     * @OA\Property(property="password",type="string",example="Admin@123"),
      *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */

--- a/www/app/Http/Requests/UpdateClienteRequest.php
+++ b/www/app/Http/Requests/UpdateClienteRequest.php
@@ -4,18 +4,30 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
+/**
+ * @OA\Schema(
+ *   title="Requisição para atualizar cliente",
+ *   type="object",
+ *   required={"nome", "email", "telefone", "cpf_cnpj"}
+ * )
+ */
 class UpdateClienteRequest extends FormRequest
 {
     /**
      * Get the validation rules that apply to the request.
+     *
+     * @OA\Property(property="nome",type="string",example="Cliente 01"),
+     * @OA\Property(property="email",type="string",example="cliente-01@admin.com"),
+     * @OA\Property(property="telefone",type="string",example="(11) 99999-9990"),
+     * @OA\Property(property="cpf_cnpj",type="string",example="999.999.999-99"),
      *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {
         return [
-            'email'     => "required|email|unique:clientes,email,{$this->cliente->id},id,integrador_id,{$this->user()->id}",
             'nome'      => 'required|max:100',
+            'email'     => "required|email|unique:clientes,email,{$this->cliente->id},id,integrador_id,{$this->user()->id}",
             'telefone'  => 'required|celular_com_ddd',
             'cpf_cnpj'  => "required|cpf_ou_cnpj|unique:clientes,cpf_cnpj,{$this->cliente->id},id,integrador_id,{$this->user()->id}",
         ];

--- a/www/app/Http/Requests/UpdateIntegradorRequest.php
+++ b/www/app/Http/Requests/UpdateIntegradorRequest.php
@@ -4,6 +4,12 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
+/**
+ * @OA\Schema(
+ *   title="Requisição para atualizar integrador",
+ *   type="object",
+ * )
+ */
 class UpdateIntegradorRequest extends FormRequest
 {
     /**
@@ -16,6 +22,11 @@ class UpdateIntegradorRequest extends FormRequest
 
     /**
      * Get the validation rules that apply to the request.
+     *
+     * @OA\Property(property="nome",type="string",example="integrador-01"),
+     * @OA\Property(property="email",type="string",example="integrador-01@admin.com"),
+     * @OA\Property(property="password",type="string",example="Admin@123"),
+     * @OA\Property(property="password_confirmation",type="string",example="Admin@123"),
      *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */

--- a/www/app/Http/Requests/UpdateIntegradorTipoRequest.php
+++ b/www/app/Http/Requests/UpdateIntegradorTipoRequest.php
@@ -4,11 +4,19 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
+/**
+ * @OA\Schema(
+ *   title="Requisição para atualizar tipo do integrador",
+ *   type="object",
+ * )
+ */
 class UpdateIntegradorTipoRequest extends FormRequest
 {
 
     /**
      * Get the validation rules that apply to the request.
+     *
+     * @OA\Property(property="tipo",type="string", enum={"INTEGRADOR", "ADMIN"}),
      *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */

--- a/www/app/Http/Resources/ClienteResource.php
+++ b/www/app/Http/Resources/ClienteResource.php
@@ -5,10 +5,25 @@ namespace App\Http\Resources;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/**
+ * @OA\Schema(
+ *   title="Retorna dados do cliente",
+ *   type="object",
+ * )
+ */
 class ClienteResource extends JsonResource
 {
     /**
      * Transform the resource into an array.
+     *
+     * @OA\Property(property="id",type="integer",example=1),
+     * @OA\Property(property="integrador",type="object", ref="#/components/schemas/IntegradorResource"),
+     * @OA\Property(property="nome",type="string",example="Integrador-01"),
+     * @OA\Property(property="email",type="string",example="integrador-01@admin.com"),
+     * @OA\Property(property="telefone",type="string",example="(11) 99999-9990"),
+     * @OA\Property(property="cpf_cnpj",type="string",example="99999999999"),
+     * @OA\Property(property="created_at",type="string",example="2024-04-30T23:29:52.000000Z"),
+     * @OA\Property(property="updated_at",type="string",example="2024-04-30T23:29:52.000000Z"),
      *
      * @return array<string, mixed>
      */

--- a/www/app/Http/Resources/IntegradorResource.php
+++ b/www/app/Http/Resources/IntegradorResource.php
@@ -5,10 +5,24 @@ namespace App\Http\Resources;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/**
+ * @OA\Schema(
+ *   title="Retornoadados do integrador",
+ *   type="object",
+ * )
+ */
 class IntegradorResource extends JsonResource
 {
     /**
      * Transform the resource into an array.
+     *
+     * @OA\Property(property="id",type="integer",example=1),
+     * @OA\Property(property="nome",type="string",example="Admin"),
+     * @OA\Property(property="email",type="string",example="admin@admin.com"),
+     * @OA\Property(property="tipo",type="string",example="INTEGRADOR"),
+     * @OA\Property(property="ativo",type="boolean",example=true),
+     * @OA\Property(property="created_at",type="string",example="2024-04-30T23:29:52.000000Z"),
+     * @OA\Property(property="updated_at",type="string",example="2024-04-30T23:29:52.000000Z"),
      *
      * @return array<string, mixed>
      */

--- a/www/app/Models/Integrador.php
+++ b/www/app/Models/Integrador.php
@@ -41,6 +41,7 @@ class Integrador extends Authenticatable
     protected $hidden = [
         'password',
         'remember_token',
+        'email_verified_at',
     ];
 
     /**

--- a/www/app/Pagination/CustomPaginator.php
+++ b/www/app/Pagination/CustomPaginator.php
@@ -4,8 +4,36 @@ namespace App\Pagination;
 
 use Illuminate\Pagination\LengthAwarePaginator;
 
+/**
+ * @OA\Schema(
+ *   title="Retorno de paginação",
+ *   type="object",
+ * )
+ */
 class CustomPaginator extends LengthAwarePaginator
 {
+    /**
+     * @OA\Property(property="meta", type="object",
+     *   @OA\Property(property="current_page", type="integer", example=1),
+     *   @OA\Property(property="first_page_url", type="string", example="http://localhost:8000/api/modelo?page=1"),
+     *   @OA\Property(property="from", type="integer", example=1),
+     *   @OA\Property(property="last_page", type="integer", example=1),
+     *   @OA\Property(property="last_page_url", type="string", example="http://localhost:8000/api/modelo?page=1"),
+     *   @OA\Property(property="next_page_url", type="string", example=null),
+     *   @OA\Property(property="path", type="string", example="http://localhost:8000/api/modelo"),
+     *   @OA\Property(property="per_page", type="integer", example=15),
+     *   @OA\Property(property="prev_page_url", type="string", example=null),
+     *   @OA\Property(property="to", type="integer", example=3),
+     *   @OA\Property(property="total", type="integer", example=3),
+     * ),
+     * @OA\Property(property="links", type="array",
+     *   @OA\Items(type="object",
+     *       @OA\Property(property="url", type="string", example="http://localhost:8000/api/modelo?page=1"),
+     *       @OA\Property(property="label", type="string", example="1"),
+     *       @OA\Property(property="active", type="boolean", example=true),
+     *   ),
+     * ),
+     */
     public function toArray(): array
     {
         return [

--- a/www/app/Services/IntegradorService.php
+++ b/www/app/Services/IntegradorService.php
@@ -36,10 +36,7 @@ class IntegradorService
         if (Auth::attempt($request) && auth()->user()->isActive()) {
             return $this->response(
                 message: 'Login efetuado com sucesso.',
-                content: auth()
-                    ->user()
-                    ->createToken("API TOKEN")
-                    ->plainTextToken
+                content: auth()->user()->createToken("API TOKEN")->plainTextToken
             );
         }
 

--- a/www/composer.json
+++ b/www/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
+        "darkaonline/l5-swagger": "^8.6",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",

--- a/www/composer.lock
+++ b/www/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e41413a0b5a80af813bed30b761905e",
+    "content-hash": "4213f0c82c16c1cd45c636509ef7c7dc",
     "packages": [
         {
             "name": "brick/math",
@@ -131,6 +131,86 @@
             "time": "2023-12-11T17:09:12+00:00"
         },
         {
+            "name": "darkaonline/l5-swagger",
+            "version": "8.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DarkaOnLine/L5-Swagger.git",
+                "reference": "76ce7aa61ac61c0a495c98ba2bc0b886ac4b6eaa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DarkaOnLine/L5-Swagger/zipball/76ce7aa61ac61c0a495c98ba2bc0b886ac4b6eaa",
+                "reference": "76ce7aa61ac61c0a495c98ba2bc0b886ac4b6eaa",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0 || ^2.0",
+                "ext-json": "*",
+                "laravel/framework": "^11.0 || ^10.0 || ^9.0 || >=8.40.0 || ^7.0",
+                "php": "^7.2 || ^8.0",
+                "swagger-api/swagger-ui": "^3.0 || >=4.1.3",
+                "symfony/yaml": "^5.0 || ^6.0 || ^7.0",
+                "zircote/swagger-php": "^3.2.0 || ^4.0.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "1.*",
+                "orchestra/testbench": "^9.0 || ^8.0 || 7.* || ^6.15 || 5.*",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^11.0 || ^10.0 || ^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "L5Swagger\\L5SwaggerServiceProvider"
+                    ],
+                    "aliases": {
+                        "L5Swagger": "L5Swagger\\L5SwaggerFacade"
+                    }
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "L5Swagger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Darius Matulionis",
+                    "email": "darius@matulionis.lt"
+                }
+            ],
+            "description": "OpenApi or Swagger integration to Laravel",
+            "keywords": [
+                "api",
+                "documentation",
+                "laravel",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/DarkaOnLine/L5-Swagger/issues",
+                "source": "https://github.com/DarkaOnLine/L5-Swagger/tree/8.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DarkaOnLine",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-13T14:06:52+00:00"
+        },
+        {
             "name": "dflydev/dot-access-data",
             "version": "v3.0.2",
             "source": {
@@ -204,6 +284,82 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.2"
             },
             "time": "2022-10-27T11:44:00+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f",
+                "reference": "e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2 || ^3",
+                "ext-tokenizer": "*",
+                "php": "^7.2 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "doctrine/cache": "^2.0",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.8.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "symfony/cache": "^5.4 || ^6",
+                "vimeo/psalm": "^4.10"
+            },
+            "suggest": {
+                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/2.0.1"
+            },
+            "time": "2023-02-02T22:02:53+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -2580,6 +2736,55 @@
             "time": "2023-11-12T21:59:55+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
             "name": "psr/clock",
             "version": "1.0.0",
             "source": {
@@ -3294,6 +3499,67 @@
                 }
             ],
             "time": "2023-11-08T05:53:05+00:00"
+        },
+        {
+            "name": "swagger-api/swagger-ui",
+            "version": "v5.17.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swagger-api/swagger-ui.git",
+                "reference": "a88cce2cb3ce746dfb3eda1380ac42b33670da22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/a88cce2cb3ce746dfb3eda1380ac42b33670da22",
+                "reference": "a88cce2cb3ce746dfb3eda1380ac42b33670da22",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Anna Bodnia",
+                    "email": "anna.bodnia@gmail.com"
+                },
+                {
+                    "name": "Buu Nguyen",
+                    "email": "buunguyen@gmail.com"
+                },
+                {
+                    "name": "Josh Ponelat",
+                    "email": "jponelat@gmail.com"
+                },
+                {
+                    "name": "Kyle Shockey",
+                    "email": "kyleshockey1@gmail.com"
+                },
+                {
+                    "name": "Robert Barnwell",
+                    "email": "robert@robertismy.name"
+                },
+                {
+                    "name": "Sahar Jafari",
+                    "email": "shr.jafari@gmail.com"
+                }
+            ],
+            "description": " Swagger UI is a collection of HTML, Javascript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API.",
+            "homepage": "http://swagger.io",
+            "keywords": [
+                "api",
+                "documentation",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/swagger-api/swagger-ui/issues",
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.17.2"
+            },
+            "time": "2024-04-25T14:26:19+00:00"
         },
         {
             "name": "symfony/console",
@@ -5527,6 +5793,78 @@
             "time": "2024-03-19T11:56:30+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v6.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "d75715985f0f94f978e3a8fa42533e10db921b90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d75715985f0f94f978e3a8fa42533e10db921b90",
+                "reference": "d75715985f0f94f978e3a8fa42533e10db921b90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<5.4"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v6.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-23T14:51:35+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "v2.2.7",
             "source": {
@@ -5794,6 +6132,87 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "4.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "b46a36d006f4db4d761995a5add1e7ab0386ed1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/b46a36d006f4db4d761995a5add1e7ab0386ed1d",
+                "reference": "b46a36d006f4db4d761995a5add1e7ab0386ed1d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.2",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": ">=2.2",
+                "symfony/yaml": ">=3.3"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11",
+                "doctrine/annotations": "^1.7 || ^2.0",
+                "friendsofphp/php-cs-fixer": "^2.17 || ^3.47.1",
+                "phpstan/phpstan": "^1.6",
+                "phpunit/phpunit": ">=8",
+                "vimeo/psalm": "^4.23"
+            },
+            "suggest": {
+                "doctrine/annotations": "^1.7 || ^2.0"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "swagger-php - Generate interactive documentation for your RESTful API using phpdoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php/",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/4.9.0"
+            },
+            "time": "2024-04-18T22:32:11+00:00"
         }
     ],
     "packages-dev": [
@@ -8111,78 +8530,6 @@
                 }
             ],
             "time": "2024-04-16T08:57:16+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v6.4.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "d75715985f0f94f978e3a8fa42533e10db921b90"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/d75715985f0f94f978e3a8fa42533e10db921b90",
-                "reference": "d75715985f0f94f978e3a8fa42533e10db921b90",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<5.4"
-            },
-            "require-dev": {
-                "symfony/console": "^5.4|^6.0|^7.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.3"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-01-23T14:51:35+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/www/config/l5-swagger.php
+++ b/www/config/l5-swagger.php
@@ -1,0 +1,299 @@
+<?php
+
+return [
+    'default' => 'default',
+    'documentations' => [
+        'default' => [
+            'api' => [
+                'title' => 'L5 Swagger UI | Gestao Projetos de Energia Solar',
+            ],
+
+            'routes' => [
+                /*
+                 * Route for accessing api documentation interface
+                */
+                'api' => 'api/documentation',
+            ],
+            'paths' => [
+                /*
+                 * Edit to include full URL in ui for assets
+                */
+                'use_absolute_path' => env('L5_SWAGGER_USE_ABSOLUTE_PATH', true),
+
+                /*
+                 * File name of the generated json documentation file
+                */
+                'docs_json' => 'api-docs.json',
+
+                /*
+                 * File name of the generated YAML documentation file
+                */
+                'docs_yaml' => 'api-docs.yaml',
+
+                /*
+                * Set this to `json` or `yaml` to determine which documentation file to use in UI
+                */
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'json'),
+
+                /*
+                 * Absolute paths to directory containing the swagger annotations are stored.
+                */
+                'annotations' => [
+                    base_path('app'),
+                ],
+
+            ],
+        ],
+    ],
+    'defaults' => [
+        'routes' => [
+            /*
+             * Route for accessing parsed swagger annotations.
+            */
+            'docs' => 'docs',
+
+            /*
+             * Route for Oauth2 authentication callback.
+            */
+            'oauth2_callback' => 'api/oauth2-callback',
+
+            /*
+             * Middleware allows to prevent unexpected access to API documentation
+            */
+            'middleware' => [
+                'api' => [],
+                'asset' => [],
+                'docs' => [],
+                'oauth2_callback' => [],
+            ],
+
+            /*
+             * Route Group options
+            */
+            'group_options' => [],
+        ],
+
+        'paths' => [
+            /*
+             * Absolute path to location where parsed annotations will be stored
+            */
+            'docs' => storage_path('api-docs'),
+
+            /*
+             * Absolute path to directory where to export views
+            */
+            'views' => base_path('resources/views/vendor/l5-swagger'),
+
+            /*
+             * Edit to set the api's base path
+            */
+            'base' => env('L5_SWAGGER_BASE_PATH', null),
+
+            /*
+             * Edit to set path where swagger ui assets should be stored
+            */
+            'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @deprecated Please use `scanOptions.exclude`
+             * `scanOptions.exclude` overwrites this
+            */
+            'excludes' => [],
+        ],
+
+        'scanOptions' => [
+            /**
+             * analyser: defaults to \OpenApi\StaticAnalyser .
+             *
+             * @see \OpenApi\scan
+             */
+            'analyser' => null,
+
+            /**
+             * analysis: defaults to a new \OpenApi\Analysis .
+             *
+             * @see \OpenApi\scan
+             */
+            'analysis' => null,
+
+            /**
+             * Custom query path processors classes.
+             *
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/processors/schema-query-parameter
+             * @see \OpenApi\scan
+             */
+            'processors' => [
+                // new \App\SwaggerProcessors\SchemaQueryParameter(),
+            ],
+
+            /**
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php) .
+             *
+             * @see \OpenApi\scan
+             */
+            'pattern' => null,
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @note This option overwrites `paths.excludes`
+             * @see \OpenApi\scan
+            */
+            'exclude' => [],
+
+            /*
+             * Allows to generate specs either for OpenAPI 3.0.0 or OpenAPI 3.1.0.
+             * By default the spec will be in version 3.0.0
+             */
+            'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', \L5Swagger\Generator::OPEN_API_DEFAULT_SPEC_VERSION),
+        ],
+
+        /*
+         * API security definitions. Will be generated into documentation file.
+        */
+        'securityDefinitions' => [
+            'securitySchemes' => [
+                /*
+                 * Examples of Security schemes
+                */
+                /*
+                'api_key_security_example' => [ // Unique name of security
+                    'type' => 'apiKey', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for security scheme',
+                    'name' => 'api_key', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                'oauth2_security_example' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for oauth2 security scheme.',
+                    'flow' => 'implicit', // The flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
+                    'authorizationUrl' => 'http://example.com/auth', // The authorization URL to be used for (implicit/accessCode)
+                    //'tokenUrl' => 'http://example.com/auth' // The authorization URL to be used for (password/application/accessCode)
+                    'scopes' => [
+                        'read:projects' => 'read your projects',
+                        'write:projects' => 'modify projects in your account',
+                    ]
+                ],
+                */
+
+                /* Open API 3.0 support
+                'passport' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Laravel passport oauth2 security.',
+                    'in' => 'header',
+                    'scheme' => 'https',
+                    'flows' => [
+                        "password" => [
+                            "authorizationUrl" => config('app.url') . '/oauth/authorize',
+                            "tokenUrl" => config('app.url') . '/oauth/token',
+                            "refreshUrl" => config('app.url') . '/token/refresh',
+                            "scopes" => []
+                        ],
+                    ],
+                ],
+                */
+                'sanctum' => [ // Unique name of security
+                    'type' => 'apiKey', // Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Insira o token no formato (Bearer <token>)',
+                    'name' => 'Authorization', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+            ],
+            'security' => [
+                /*
+                 * Examples of Securities
+                */
+                [
+                    /*
+                    'oauth2_security_example' => [
+                        'read',
+                        'write'
+                    ],
+
+                    'passport' => []
+                    */],
+            ],
+        ],
+
+        /*
+         * Set this to `true` in development mode so that docs would be regenerated on each request
+         * Set this to `false` to disable swagger generation on production
+        */
+        'generate_always' => env('L5_SWAGGER_GENERATE_ALWAYS', false),
+
+        /*
+         * Set this to `true` to generate a copy of documentation in yaml format
+        */
+        'generate_yaml_copy' => env('L5_SWAGGER_GENERATE_YAML_COPY', false),
+
+        /*
+         * Edit to trust the proxy's ip address - needed for AWS Load Balancer
+         * string[]
+        */
+        'proxy' => false,
+
+        /*
+         * Configs plugin allows to fetch external configs instead of passing them to SwaggerUIBundle.
+         * See more at: https://github.com/swagger-api/swagger-ui#configs-plugin
+        */
+        'additional_config_url' => null,
+
+        /*
+         * Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths alphanumerically),
+         * 'method' (sort by HTTP method).
+         * Default is the order returned by the server unchanged.
+        */
+        'operations_sort' => env('L5_SWAGGER_OPERATIONS_SORT', null),
+
+        /*
+         * Pass the validatorUrl parameter to SwaggerUi init on the JS side.
+         * A null value here disables validation.
+        */
+        'validator_url' => null,
+
+        /*
+         * Swagger UI configuration parameters
+        */
+        'ui' => [
+            'display' => [
+                /*
+                 * Controls the default expansion setting for the operations and tags. It can be :
+                 * 'list' (expands only the tags),
+                 * 'full' (expands the tags and operations),
+                 * 'none' (expands nothing).
+                 */
+                'doc_expansion' => env('L5_SWAGGER_UI_DOC_EXPANSION', 'none'),
+
+                /**
+                 * If set, enables filtering. The top bar will show an edit box that
+                 * you can use to filter the tagged operations that are shown. Can be
+                 * Boolean to enable or disable, or a string, in which case filtering
+                 * will be enabled using that string as the filter expression. Filtering
+                 * is case-sensitive matching the filter expression anywhere inside
+                 * the tag.
+                 */
+                'filter' => env('L5_SWAGGER_UI_FILTERS', true), // true | false
+            ],
+
+            'authorization' => [
+                /*
+                 * If set to true, it persists authorization data, and it would not be lost on browser close/refresh
+                 */
+                'persist_authorization' => env('L5_SWAGGER_UI_PERSIST_AUTHORIZATION', false),
+
+                'oauth2' => [
+                    /*
+                    * If set to true, adds PKCE to AuthorizationCodeGrant flow
+                    */
+                    'use_pkce_with_authorization_code_grant' => false,
+                ],
+            ],
+        ],
+        /*
+         * Constants which can be used in annotations
+         */
+        'constants' => [
+            'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://my-default-host.com'),
+        ],
+    ],
+];

--- a/www/resources/views/vendor/l5-swagger/index.blade.php
+++ b/www/resources/views/vendor/l5-swagger/index.blade.php
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{config('l5-swagger.documentations.'.$documentation.'.api.title')}}</title>
+    <link rel="stylesheet" type="text/css" href="{{ l5_swagger_asset($documentation, 'swagger-ui.css') }}">
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-32x32.png') }}" sizes="32x32"/>
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-16x16.png') }}" sizes="16x16"/>
+    <style>
+    html
+    {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+    }
+    *,
+    *:before,
+    *:after
+    {
+        box-sizing: inherit;
+    }
+
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+    </style>
+</head>
+
+<body>
+<div id="swagger-ui"></div>
+
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-bundle.js') }}"></script>
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-standalone-preset.js') }}"></script>
+<script>
+    window.onload = function() {
+        // Build a system
+        const ui = SwaggerUIBundle({
+            dom_id: '#swagger-ui',
+            url: "{!! $urlToDocs !!}",
+            operationsSorter: {!! isset($operationsSorter) ? '"' . $operationsSorter . '"' : 'null' !!},
+            configUrl: {!! isset($configUrl) ? '"' . $configUrl . '"' : 'null' !!},
+            validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
+            oauth2RedirectUrl: "{{ route('l5-swagger.'.$documentation.'.oauth2_callback', [], $useAbsolutePath) }}",
+
+            requestInterceptor: function(request) {
+                request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
+                return request;
+            },
+
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIStandalonePreset
+            ],
+
+            plugins: [
+                SwaggerUIBundle.plugins.DownloadUrl
+            ],
+
+            layout: "StandaloneLayout",
+            docExpansion : "{!! config('l5-swagger.defaults.ui.display.doc_expansion', 'none') !!}",
+            deepLinking: true,
+            filter: {!! config('l5-swagger.defaults.ui.display.filter') ? 'true' : 'false' !!},
+            persistAuthorization: "{!! config('l5-swagger.defaults.ui.authorization.persist_authorization') ? 'true' : 'false' !!}",
+
+        })
+
+        window.ui = ui
+
+        @if(in_array('oauth2', array_column(config('l5-swagger.defaults.securityDefinitions.securitySchemes'), 'type')))
+        ui.initOAuth({
+            usePkceWithAuthorizationCodeGrant: "{!! (bool)config('l5-swagger.defaults.ui.authorization.oauth2.use_pkce_with_authorization_code_grant') !!}"
+        })
+        @endif
+    }
+</script>
+</body>
+</html>

--- a/www/storage/api-docs/api-docs.json
+++ b/www/storage/api-docs/api-docs.json
@@ -1,0 +1,1351 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Gestao Projetos de Energia Solar",
+        "description": "Sistema CRUD desenvolvido utilizando a framework Laravel em PHP é voltado para a gestão de projetos de energia solar. Ele adere aos princípios da arquitetura limpa (Clean Architecture), incorporando testes unitários para assegurar a qualidade do código. Além disso, oferece uma documentação abrangente para facilitar o entendimento e a manutenção do sistema.",
+        "contact": {
+            "email": "adriano@instalustres.com.br"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "http://localhost:8000",
+            "description": "Servidor local"
+        }
+    ],
+    "paths": {
+        "/api/clientes": {
+            "get": {
+                "tags": [
+                    "Clientes"
+                ],
+                "summary": "Exibe lista de clientes",
+                "description": "",
+                "operationId": "getClientesIndex",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "Filtrar pelo ID",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "nome",
+                        "in": "query",
+                        "description": "Filtrar pelo nome",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "email",
+                        "in": "query",
+                        "description": "Filtrar pelo email",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "telefone",
+                        "in": "query",
+                        "description": "Filtrar pelo telefone",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "cpf_cnpj",
+                        "in": "query",
+                        "description": "Filtrar pelo CPF/CNPJ",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ordenar_id",
+                        "in": "query",
+                        "description": "Ordenar pelo ID",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "ordenar_nome",
+                        "in": "query",
+                        "description": "Ordenar pelo nome",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Lista de clientes."
+                                        },
+                                        "content": {
+                                            "properties": {
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/ClienteResource"
+                                                    }
+                                                },
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/CustomPaginator"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "code": {
+                                            "type": "integer",
+                                            "example": "200"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request."
+                    },
+                    "401": {
+                        "description": "Unauthorized."
+                    },
+                    "403": {
+                        "description": "Forbidden."
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Clientes"
+                ],
+                "summary": "Cadastra novo cliente",
+                "description": "",
+                "operationId": "postClientesStore",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateClienteRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Cliente cadastrado com sucesso."
+                                        },
+                                        "content": {
+                                            "$ref": "#/components/schemas/ClienteResource"
+                                        },
+                                        "code": {
+                                            "type": "integer",
+                                            "example": "200"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request."
+                    },
+                    "401": {
+                        "description": "Unauthorized."
+                    },
+                    "403": {
+                        "description": "Forbidden."
+                    },
+                    "422": {
+                        "description": "Unprocessable Content.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "O campo cpf cnpj não é um CPF ou CNPJ válido."
+                                        },
+                                        "errors": {
+                                            "properties": {
+                                                "nome": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "example": "O campo cpf cnpj não é um CPF ou CNPJ válido."
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/clientes/{id}": {
+            "get": {
+                "tags": [
+                    "Clientes"
+                ],
+                "summary": "Pesquisa cliente pelo ID",
+                "description": "",
+                "operationId": "getClientesShow",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID do cliente",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "example": 2
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Cliente ID: 2"
+                                        },
+                                        "content": {
+                                            "$ref": "#/components/schemas/ClienteResource"
+                                        },
+                                        "code": {
+                                            "type": "integer",
+                                            "example": "200"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request."
+                    },
+                    "401": {
+                        "description": "Unauthenticated."
+                    },
+                    "403": {
+                        "description": "Forbidden."
+                    },
+                    "404": {
+                        "description": "Not Found."
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Clientes"
+                ],
+                "summary": "Atualiza os dados do cliente",
+                "description": "",
+                "operationId": "putClientesUpdate",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID do cliente",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "example": 2
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateClienteRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Cliente atualizado com sucesso."
+                                        },
+                                        "content": {
+                                            "$ref": "#/components/schemas/ClienteResource"
+                                        },
+                                        "code": {
+                                            "type": "integer",
+                                            "example": "200"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request."
+                    },
+                    "401": {
+                        "description": "Unauthenticated."
+                    },
+                    "403": {
+                        "description": "Forbidden."
+                    },
+                    "404": {
+                        "description": "Not Found."
+                    },
+                    "422": {
+                        "description": "Unprocessable Content.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "O campo cpf cnpj não é um CPF ou CNPJ válido."
+                                        },
+                                        "errors": {
+                                            "properties": {
+                                                "email": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "example": "O campo cpf cnpj não é um CPF ou CNPJ válido."
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/integradores": {
+            "get": {
+                "tags": [
+                    "Integradores"
+                ],
+                "summary": "Exibe lista de integradores",
+                "description": "",
+                "operationId": "getIntegradoresIndex",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "Filtrar pelo ID",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "nome",
+                        "in": "query",
+                        "description": "Filtrar pelo nome",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "email",
+                        "in": "query",
+                        "description": "Filtrar pelo email",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tipo",
+                        "in": "query",
+                        "description": "Filtrar pelo tipo",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "INTEGRADOR",
+                                "ADMIN"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "ativo",
+                        "in": "query",
+                        "description": "Filtrar pelo status",
+                        "schema": {
+                            "type": "integer",
+                            "enum": [
+                                0,
+                                1
+                            ]
+                        }
+                    },
+                    {
+                        "name": "ordenar_id",
+                        "in": "query",
+                        "description": "Ordenar pelo ID",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "ordenar_nome",
+                        "in": "query",
+                        "description": "Ordenar pelo nome",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Lista de integradores."
+                                        },
+                                        "content": {
+                                            "properties": {
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/IntegradorResource"
+                                                    }
+                                                },
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/CustomPaginator"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "code": {
+                                            "type": "integer",
+                                            "example": "200"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request."
+                    },
+                    "401": {
+                        "description": "Unauthorized."
+                    },
+                    "403": {
+                        "description": "Forbidden."
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Integradores"
+                ],
+                "summary": "Cadastra novo integrador",
+                "description": "",
+                "operationId": "postIntegradoresStore",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateIntegradorRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Integrador cadastrado com sucesso."
+                                        },
+                                        "content": {
+                                            "$ref": "#/components/schemas/IntegradorResource"
+                                        },
+                                        "code": {
+                                            "type": "integer",
+                                            "example": "200"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request."
+                    },
+                    "401": {
+                        "description": "Unauthorized."
+                    },
+                    "403": {
+                        "description": "Forbidden."
+                    },
+                    "422": {
+                        "description": "Unprocessable Content.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "O campo nome é obrigatório. (e mais 1 erro)"
+                                        },
+                                        "errors": {
+                                            "properties": {
+                                                "nome": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "example": "O campo nome é obrigatório."
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/auth/login": {
+            "post": {
+                "tags": [
+                    "Login"
+                ],
+                "summary": "Envie seu e-mail e senha e retornaremos um token. Use o token no cabeçalho 'Authorization' da requisição como 'Bearer TOKEN'",
+                "description": "",
+                "operationId": "postIntegradoresLogin",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/LoginIntegradorRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Login efetuado com sucesso."
+                                        },
+                                        "content": {
+                                            "type": "string",
+                                            "example": "99|OOawESyfhebDhYX0LXxnn5as3fV1R3B79uZvH22Ec0df7515"
+                                        },
+                                        "code": {
+                                            "type": "integer",
+                                            "example": "200"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request."
+                    },
+                    "401": {
+                        "description": "Unauthenticated."
+                    },
+                    "422": {
+                        "description": "Unprocessable Content.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "O campo email é obrigatório. (e mais 1 erro)"
+                                        },
+                                        "errors": {
+                                            "properties": {
+                                                "email": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "example": "O campo email é obrigatório."
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/integradores/{id}": {
+            "put": {
+                "tags": [
+                    "Integradores"
+                ],
+                "summary": "Atualiza os dados do integrador",
+                "description": "",
+                "operationId": "putIntegradoresUpdate",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID do integrador",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "example": 2
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateIntegradorRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Integrador atualizado com sucesso."
+                                        },
+                                        "content": {
+                                            "$ref": "#/components/schemas/IntegradorResource"
+                                        },
+                                        "code": {
+                                            "type": "integer",
+                                            "example": "200"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request."
+                    },
+                    "401": {
+                        "description": "Unauthenticated."
+                    },
+                    "403": {
+                        "description": "Forbidden."
+                    },
+                    "404": {
+                        "description": "Not Found."
+                    },
+                    "422": {
+                        "description": "Unprocessable Content.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "O campo email já está sendo utilizado."
+                                        },
+                                        "errors": {
+                                            "properties": {
+                                                "email": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "example": "O campo email já está sendo utilizado."
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/integradores/{id}/tipo": {
+            "patch": {
+                "tags": [
+                    "Integradores"
+                ],
+                "summary": "Atualiza o tipo do integrador",
+                "description": "",
+                "operationId": "pathIntegradoresType",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID do integrador",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "example": 2
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateIntegradorTipoRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Tipo de integrador atualizado com sucesso."
+                                        },
+                                        "content": {
+                                            "$ref": "#/components/schemas/IntegradorResource"
+                                        },
+                                        "code": {
+                                            "type": "integer",
+                                            "example": "200"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request."
+                    },
+                    "401": {
+                        "description": "Unauthenticated."
+                    },
+                    "403": {
+                        "description": "Forbidden."
+                    },
+                    "404": {
+                        "description": "Not Found."
+                    },
+                    "422": {
+                        "description": "Unprocessable Content.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "O campo tipo selecionado é inválido."
+                                        },
+                                        "errors": {
+                                            "properties": {
+                                                "email": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "example": "O campo tipo selecionado é inválido."
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/integradores/{id}/desativar": {
+            "patch": {
+                "tags": [
+                    "Integradores"
+                ],
+                "summary": "Desativar o integrador",
+                "description": "",
+                "operationId": "pathIntegradoresDeactive",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID do integrador",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "example": 2
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Integrador desativado com sucesso."
+                                        },
+                                        "content": {
+                                            "$ref": "#/components/schemas/IntegradorResource"
+                                        },
+                                        "code": {
+                                            "type": "integer",
+                                            "example": "200"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request."
+                    },
+                    "401": {
+                        "description": "Unauthenticated."
+                    },
+                    "403": {
+                        "description": "Forbidden."
+                    },
+                    "404": {
+                        "description": "Not Found."
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/integradores/{id}/ativar": {
+            "patch": {
+                "tags": [
+                    "Integradores"
+                ],
+                "summary": "Ativar o integrador",
+                "description": "",
+                "operationId": "pathIntegradoresActive",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID do integrador",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "example": 2
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Integrador ativado com sucesso."
+                                        },
+                                        "content": {
+                                            "$ref": "#/components/schemas/IntegradorResource"
+                                        },
+                                        "code": {
+                                            "type": "integer",
+                                            "example": "200"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request."
+                    },
+                    "401": {
+                        "description": "Unauthenticated."
+                    },
+                    "403": {
+                        "description": "Forbidden."
+                    },
+                    "404": {
+                        "description": "Not Found."
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "CreateClienteRequest": {
+                "title": "Requisição para gravar cliente",
+                "required": [
+                    "nome",
+                    "email",
+                    "telefone",
+                    "cpf_cnpj"
+                ],
+                "properties": {
+                    "nome": {
+                        "description": "Get the validation rules that apply to the request.",
+                        "type": "string",
+                        "example": "Cliente 01"
+                    },
+                    "email": {
+                        "type": "string",
+                        "example": "cliente-01@admin.com"
+                    },
+                    "telefone": {
+                        "type": "string",
+                        "example": "(11) 99999-9990"
+                    },
+                    "cpf_cnpj": {
+                        "type": "string",
+                        "example": "999.999.999-99"
+                    }
+                },
+                "type": "object"
+            },
+            "CreateIntegradorRequest": {
+                "title": "Requisição para gravar integrador",
+                "required": [
+                    "nome",
+                    "email",
+                    "tipo",
+                    "password",
+                    "password_confirmation"
+                ],
+                "properties": {
+                    "nome": {
+                        "description": "Get the validation rules that apply to the request.",
+                        "type": "string",
+                        "example": "admin@admin.com"
+                    },
+                    "email": {
+                        "type": "string",
+                        "example": "admin@admin.com"
+                    },
+                    "tipo": {
+                        "type": "string",
+                        "example": "INTEGRADOR"
+                    },
+                    "password": {
+                        "type": "string",
+                        "example": "Admin@123"
+                    },
+                    "password_confirmation": {
+                        "type": "string",
+                        "example": "Admin@123"
+                    }
+                },
+                "type": "object"
+            },
+            "LoginIntegradorRequest": {
+                "title": "Requisição para efetuar login",
+                "required": [
+                    "email",
+                    "password"
+                ],
+                "properties": {
+                    "email": {
+                        "description": "Get the validation rules that apply to the request.",
+                        "type": "string",
+                        "example": "admin@admin.com"
+                    },
+                    "password": {
+                        "type": "string",
+                        "example": "Admin@123"
+                    }
+                },
+                "type": "object"
+            },
+            "UpdateClienteRequest": {
+                "title": "Requisição para atualizar cliente",
+                "required": [
+                    "nome",
+                    "email",
+                    "telefone",
+                    "cpf_cnpj"
+                ],
+                "properties": {
+                    "nome": {
+                        "description": "Get the validation rules that apply to the request.",
+                        "type": "string",
+                        "example": "Cliente 01"
+                    },
+                    "email": {
+                        "type": "string",
+                        "example": "cliente-01@admin.com"
+                    },
+                    "telefone": {
+                        "type": "string",
+                        "example": "(11) 99999-9990"
+                    },
+                    "cpf_cnpj": {
+                        "type": "string",
+                        "example": "999.999.999-99"
+                    }
+                },
+                "type": "object"
+            },
+            "UpdateIntegradorRequest": {
+                "title": "Requisição para atualizar integrador",
+                "properties": {
+                    "nome": {
+                        "description": "Get the validation rules that apply to the request.",
+                        "type": "string",
+                        "example": "integrador-01"
+                    },
+                    "email": {
+                        "type": "string",
+                        "example": "integrador-01@admin.com"
+                    },
+                    "password": {
+                        "type": "string",
+                        "example": "Admin@123"
+                    },
+                    "password_confirmation": {
+                        "type": "string",
+                        "example": "Admin@123"
+                    }
+                },
+                "type": "object"
+            },
+            "UpdateIntegradorTipoRequest": {
+                "title": "Requisição para atualizar tipo do integrador",
+                "properties": {
+                    "tipo": {
+                        "description": "Get the validation rules that apply to the request.",
+                        "type": "string",
+                        "enum": [
+                            "INTEGRADOR",
+                            "ADMIN"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "ClienteResource": {
+                "title": "Retorna dados do cliente",
+                "properties": {
+                    "id": {
+                        "description": "Transform the resource into an array.",
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "integrador": {
+                        "$ref": "#/components/schemas/IntegradorResource"
+                    },
+                    "nome": {
+                        "type": "string",
+                        "example": "Integrador-01"
+                    },
+                    "email": {
+                        "type": "string",
+                        "example": "integrador-01@admin.com"
+                    },
+                    "telefone": {
+                        "type": "string",
+                        "example": "(11) 99999-9990"
+                    },
+                    "cpf_cnpj": {
+                        "type": "string",
+                        "example": "99999999999"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "example": "2024-04-30T23:29:52.000000Z"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "example": "2024-04-30T23:29:52.000000Z"
+                    }
+                },
+                "type": "object"
+            },
+            "IntegradorResource": {
+                "title": "Retornoadados do integrador",
+                "properties": {
+                    "id": {
+                        "description": "Transform the resource into an array.",
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "nome": {
+                        "type": "string",
+                        "example": "Admin"
+                    },
+                    "email": {
+                        "type": "string",
+                        "example": "admin@admin.com"
+                    },
+                    "tipo": {
+                        "type": "string",
+                        "example": "INTEGRADOR"
+                    },
+                    "ativo": {
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "example": "2024-04-30T23:29:52.000000Z"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "example": "2024-04-30T23:29:52.000000Z"
+                    }
+                },
+                "type": "object"
+            },
+            "CustomPaginator": {
+                "title": "Retorno de paginação",
+                "properties": {
+                    "meta": {
+                        "properties": {
+                            "current_page": {
+                                "type": "integer",
+                                "example": 1
+                            },
+                            "first_page_url": {
+                                "type": "string",
+                                "example": "http://localhost:8000/api/modelo?page=1"
+                            },
+                            "from": {
+                                "type": "integer",
+                                "example": 1
+                            },
+                            "last_page": {
+                                "type": "integer",
+                                "example": 1
+                            },
+                            "last_page_url": {
+                                "type": "string",
+                                "example": "http://localhost:8000/api/modelo?page=1"
+                            },
+                            "next_page_url": {
+                                "type": "string",
+                                "example": null
+                            },
+                            "path": {
+                                "type": "string",
+                                "example": "http://localhost:8000/api/modelo"
+                            },
+                            "per_page": {
+                                "type": "integer",
+                                "example": 15
+                            },
+                            "prev_page_url": {
+                                "type": "string",
+                                "example": null
+                            },
+                            "to": {
+                                "type": "integer",
+                                "example": 3
+                            },
+                            "total": {
+                                "type": "integer",
+                                "example": 3
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "url": {
+                                    "type": "string",
+                                    "example": "http://localhost:8000/api/modelo?page=1"
+                                },
+                                "label": {
+                                    "type": "string",
+                                    "example": "1"
+                                },
+                                "active": {
+                                    "type": "boolean",
+                                    "example": true
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                "type": "object"
+            }
+        },
+        "securitySchemes": {
+            "sanctum": {
+                "type": "apiKey",
+                "description": "Insira o token no formato (Bearer <token>)",
+                "name": "Authorization",
+                "in": "header"
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "Login",
+            "description": "Endpoint para efetuar login"
+        },
+        {
+            "name": "Integradores",
+            "description": "Endpoints para manutenção dos Integradores (Somente integrador do tipo 'ADMIN')"
+        },
+        {
+            "name": "Clientes",
+            "description": "Endpoints para manutenção dos Clientes"
+        }
+    ]
+}


### PR DESCRIPTION
…umentar a API REST, facilitando sua compreensão e uso por outros desenvolvedores.

Esta alteração adiciona a especificação do OpenAPI Swagger à nossa API REST. A inclusão dessa especificação é fundamental para documentar de forma clara e detalhada todos os endpoints, parâmetros, respostas e demais informações relevantes da API.   Com a documentação gerada pelo Swagger, os desenvolvedores terão uma referência completa e interativa sobre como utilizar nossa API, o que facilita a integração e o desenvolvimento de novas funcionalidades. Além disso, a especificação do OpenAPI Swagger também pode ser utilizada para automatizar a geração de SDKs, testes automatizados e até mesmo para criar mocks para facilitar o desenvolvimento em paralelo.  Esta implementação segue as melhores práticas do OpenAPI Swagger, garantindo a consistência e a qualidade da documentação da nossa API. Com isso, esperamos aumentar a eficiência e a colaboração no desenvolvimento de sistemas que utilizam nossa API.