### PR TITLE
fix: :bug: Corrige um bug que causava o mau funcionamento do filtro d…

### DIFF
--- a/www/app/Filters/ClienteFilter.php
+++ b/www/app/Filters/ClienteFilter.php
@@ -16,7 +16,7 @@ class ClienteFilter extends QueryFilter
 
     public function id($id)
     {
-        return $this->builder->where('integradores.id', $id);
+        return $this->builder->where('clientes.id', $id);
     }
 
     public function nome($nome)

--- a/www/app/Filters/InstalacaoFilter.php
+++ b/www/app/Filters/InstalacaoFilter.php
@@ -16,21 +16,21 @@ class InstalacaoFilter extends QueryFilter
 
     public function id($id)
     {
-        return $this->builder->where('integradores.id', $id);
+        return $this->builder->where('instalacoes.id', $id);
     }
 
     public function nome($nome)
     {
-        return $this->builder->where('clientes.nome', 'LIKE', "%$nome%");
+        return $this->builder->where('instalacoes.nome', 'LIKE', "%$nome%");
     }
 
     public function ordenar_id($type = null)
     {
-        return $this->builder->orderBy('clientes.id', (!$type || $type == 'asc') ? 'desc' : 'asc');
+        return $this->builder->orderBy('instalacoes.id', (!$type || $type == 'asc') ? 'desc' : 'asc');
     }
 
     public function ordenar_nome($type = null)
     {
-        return $this->builder->orderBy('clientes.nome', (!$type || $type == 'asc') ? 'desc' : 'asc');
+        return $this->builder->orderBy('instalacoes.nome', (!$type || $type == 'asc') ? 'desc' : 'asc');
     }
 }


### PR DESCRIPTION
…e Cliente e Instalação, garantindo que agora ele filtre corretamente os resultados de acordo com os critérios selecionados.

Esta correção resolve um problema nos filtros de Cliente e Instalação, onde os nomes das tabelas estavam incorretos, resultando em resultados inesperados ou vazios ao aplicar filtros nessas entidades.  O erro estava relacionado à referência incorreta das tabelas no código responsável pela geração das consultas SQL dos filtros. As tabelas estavam sendo referenciadas por nomes diferentes dos utilizados no esquema do banco de dados, o que causava a falha na aplicação dos filtros.  Com esta correção, os nomes das tabelas foram ajustados para corresponder aos nomes corretos do banco de dados, garantindo que os filtros de Cliente e Instalação funcionem corretamente e forneçam os resultados esperados aos usuários.